### PR TITLE
Fix: Missing icons on macOS Tahoe 26

### DIFF
--- a/main.lisp
+++ b/main.lisp
@@ -154,7 +154,7 @@
                    :recursive
                    ;; For icon files which are symlinks
                    :links
-                   ,from-cnts ,to-cnts))))))
+                   ,from-cnts ,to-cnts)))
       ;; Copy Assets.car for CFBundleIconName resolution (Tahoe)
       (let ((car-from (merge-pathnames "Assets.car" from-cnts)))
         (when (probe-file car-from)

--- a/main.lisp
+++ b/main.lisp
@@ -155,6 +155,10 @@
                    ;; For icon files which are symlinks
                    :links
                    ,from-cnts ,to-cnts))))))
+      ;; Copy Assets.car for CFBundleIconName resolution (Tahoe)
+      (let ((car-from (merge-pathnames "Assets.car" from-cnts)))
+        (when (probe-file car-from)
+          (copy-file car-from (merge-pathnames "Assets.car" to-cnts)))))))
 
 (defun mktrampoline-app (app trampoline)
   (let ((cmd (format NIL "do shell script \"open '~A'\"" app)))

--- a/main.lisp
+++ b/main.lisp
@@ -146,19 +146,20 @@
   "Remove all icons from TO apps resources, and copy all icons FROM to it"
   (destructuring-bind (from-cnts to-cnts) (mapcar #'resources (list from to))
     (when (probe-file from-cnts)
+      ;; Always remove osacompile's Assets.car (contains only the generic "applet" icon)
+      (let ((target-car (merge-pathnames "Assets.car" to-cnts)))
+        (when (probe-file target-car)
+          (delete-file target-car)))
       ;; 🤷
       (sh `(sh:and
             (find ,to-cnts -name "*.icns" -delete)
             (rsync :include "*.icns"
+                   :include "Assets.car"
                    :exclude "*"
                    :recursive
                    ;; For icon files which are symlinks
                    :links
-                   ,from-cnts ,to-cnts)))
-      ;; Copy Assets.car for CFBundleIconName resolution (Tahoe)
-      (let ((car-from (merge-pathnames "Assets.car" from-cnts)))
-        (when (probe-file car-from)
-          (copy-file car-from (merge-pathnames "Assets.car" to-cnts)))))))
+                   ,from-cnts ,to-cnts))))))
 
 (defun mktrampoline-app (app trampoline)
   (let ((cmd (format NIL "do shell script \"open '~A'\"" app)))

--- a/main.lisp
+++ b/main.lisp
@@ -42,6 +42,7 @@
     "CFBundleDocumentTypes"
     "CFBundleGetInfoString"
     "CFBundleIconFile"
+    "CFBundleIconName"
     "CFBundleIdentifier"
     "CFBundleInfoDictionaryVersion"
     "CFBundleName"


### PR DESCRIPTION
Fixes hraban/mac-app-util#36

On macOS Tahoe (26), trampoline app icons appear to be missing or rendered incorrectly. This seems to be caused by two issues:

1. **`CFBundleIconName` not copied** — macOS Tahoe appears to prefer `CFBundleIconName` (referencing the Asset Catalog) over `CFBundleIconFile` (referencing `.icns` files) for icon resolution. Since the trampoline's plist retains the osacompile default `"applet"`, macOS can't find the real icon.
2. **`Assets.car` not synced** — osacompile generates a default `Assets.car` containing only the generic `"applet"` icon, which interferes with icon resolution. For apps that ship their own `Assets.car`, we need to replace it. For apps that don't (e.g. VS Code), we need to remove it so macOS falls back to `.icns` via `CFBundleIconFile`.

**Changes:**
- Add `CFBundleIconName` to `*copyable-app-props*`
- In `sync-icons`: always delete osacompile's default `Assets.car`, then rsync `Assets.car` alongside `*.icns` from the source app (so it's only copied when the source has one)

Note: The existing `touch` workaround is still in place. I haven't tested whether it's still needed with these changes.

**Testing:**
Tested on macOS Tahoe 26.3 (aarch64-darwin) with iTerm2, Google Chrome, Brave, VS Code, and Rectangle trampolines. Icons appear correctly in Finder and Spotlight after these changes.

With and without `Assets.car`:
<img width="263" height="153" alt="image" src="https://github.com/user-attachments/assets/abfdc041-17fc-43e7-89f6-15d8c7e463fc" />

**By submiting this PR, I agree to license this contribution under Creative Commons’ [CC0 license](https://creativecommons.org/public-domain/cc0/).**
